### PR TITLE
fixed error message `date: invalid date`

### DIFF
--- a/activity.sh
+++ b/activity.sh
@@ -29,7 +29,7 @@ fi
 ##
 for day in {1..365} ; do
     # Get the past date of the commit
-    day=$(date --date="-${day} day")
+    day2=$(date --date="-${day} day" "+%a, %d %b %Y %X %z")
 
     echo "Creating commits for ${day}"
 
@@ -39,10 +39,10 @@ for day in {1..365} ; do
     # Create the comits
     echo "Creating ${commits} commits"
     for ((i=1;i<=${commits};i++)); do
-        content=$(date -d "$day" +"%s")
+        content=$(date -d "${day2}" +"%s")
         echo ${content}-${i} >> .commits/changes
         git commit -am "Commit number ${content}-${i}" > /dev/null 2>&1
-        git commit --amend --no-edit --date "${day}" > /dev/null 2>&1
+        git commit --amend --no-edit --date "${day2}" > /dev/null 2>&1
     done
 done
 


### PR DESCRIPTION
to reproduce the error :
```bash
git clone 'https://github.com/bobbyiliev/github-activity-bash-script'
cd github-activity-bash-script
git reset --hard 23431608ff92dee0596f86615d7a253c8b5a99b0
f=$(mktemp -p /tmp tmp-XXXXXXXXXXXX)
echo -e "#!/usr/bin/env bash\n\nset -e\n\n" > $f
cat activity.sh >> $f
git tag bbb
cp -fv $f activity.sh
rm -f $f
bash -x activity.sh
git reset --hard bbb
git tag -d bbb
git log --all --decorate --oneline --graph
```